### PR TITLE
Add support for standard AWS credential environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ var options = {
     awsAccessKey:   /* AWS access key */,
     awsSecretKey:   /* AWS secret key */,
     awsRegion:   /* AWS region */,
+    awsSessionToken: /* AWS session token - used with STS assume role*/
     backupPath:     /* folder to save backups in.  default: 'DynamoDB-backup-YYYY-MM-DD-HH-mm-ss',
     base64Binary:   /* whether or not to base64 encode binary data before saving to JSON */
 };
@@ -275,7 +276,8 @@ var options = {
     stopOnFailure: /* true/false should a single failed batch stop the whole restore job? */,
     awsAccessKey: /* AWS access key */,
     awsSecretKey: /* AWS secret key */,
-    awsRegion: /* AWS region */
+    awsRegion: /* AWS region */,
+    awsSessionToken: /* AWS session token - used with STS assume role*/
 };
 
 var restore = new DynamoBackup.Restore(options);

--- a/lib/dynamo-backup.js
+++ b/lib/dynamo-backup.js
@@ -22,9 +22,10 @@ function DynamoBackup(options) {
     this.stopOnFailure = options.stopOnFailure || false;
     this.base64Binary = options.base64Binary || false;
     this.saveDataPipelineFormat = options.saveDataPipelineFormat || false;
-    this.awsAccessKey = options.awsAccessKey;
-    this.awsSecretKey = options.awsSecretKey;
-    this.awsRegion = options.awsRegion;
+    this.awsAccessKey = options.awsAccessKey || process.env.AWS_ACCESS_KEY_ID;
+    this.awsSecretKey = options.awsSecretKey || process.env.AWS_SECRET_ACCESS_KEY;
+    this.awsSessionToken = options.awsSessionToken || process.env.AWS_SESSION_TOKEN;
+    this.awsRegion = options.awsRegion || process.env.AWS_DEFAULT_REGION;
     this.debug = Boolean(options.debug);
 
     if (this.awsRegion) {
@@ -33,6 +34,7 @@ function DynamoBackup(options) {
     if (this.awsAccessKey && this.awsSecretKey) {
         params.accessKeyId = this.awsAccessKey;
         params.secretAccessKey = this.awsSecretKey;
+        params.sessionToken = this.awsSessionToken;
     }
 
     AWS.config.update(params);
@@ -61,6 +63,7 @@ DynamoBackup.prototype.backupTable = function (tableName, backupPath, callback) 
    if (self.awsAccessKey && self.awsSecretKey) {
         params.accessKey = self.awsAccessKey;
         params.secretKey = self.awsSecretKey;
+        params.sessionToken = self.awsSessionToken;
     }
 
    params.bucket = self.bucket;

--- a/lib/dynamo-restore.js
+++ b/lib/dynamo-restore.js
@@ -24,17 +24,16 @@ function DynamoRestore(options) {
     options.stopOnFailure = options.stopOnFailure || false;
 
     if (options.awsRegion) {
-        params.region = options.awsRegion;
+      params.region = options.awsRegion;
     }
     else if (!process.env.AWS_REGION) {
-        params.region = process.env.AWS_DEFAULT_REGION || 'ap-southeast-2';
+      params.region = process.env.AWS_DEFAULT_REGION || 'ap-southeast-2';
     }
 
-    if (options.awsKey && options.awsSecret) {
-        params.accessKeyhId = options.awsKey;
-        params.secretAccessKey = options.awsSecret;
-    }
-    
+    params.accessKeyId = options.awsKey || process.env.AWS_ACCESS_KEY_ID;
+    params.secretAccessKey = options.awsSecret || process.env.AWS_SECRET_ACCESS_KEY;
+    params.sessionToken = options.awsSessionToken || process.env.AWS_SESSION_TOKEN;
+
     AWS.config.update(params);
 
     this.options = options;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "dynamo-backup-to-s3",
-  "version": "0.6.1",
+  "name": "distributedlife-dynamo-backup-to-s3",
+  "version": "0.6.2",
   "author": "Dylan Lingelbach (https://github.com/dylanlingelbach)",
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
Expand AWS credential options to include session token. The session token is required if the access id and secret were created through the AWS STS assume role. I've also included the standard AWS environment variables as fallbacks if not explicitly defined.

Finally, I've passed the token down to the uploader as that has support for session tokens but this lib isn't passing it through.